### PR TITLE
Updated setup and module

### DIFF
--- a/sctop/__init__.py
+++ b/sctop/__init__.py
@@ -1,0 +1,1 @@
+from .sctop import *

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,13 @@ setuptools.setup(
         "License :: OSI Approved :: GNU General Public License (GPL)",
         "Operating System :: OS Independent",
     ],
-    package_dir={"": "sctop"},
-    packages=setuptools.find_packages(where="sctop"),
+    packages=["sctop"],
     python_requires=">=3.6",
     include_package_data=True,
+    install_requires=[
+        "numpy",
+        "pandas",
+        "scipy",
+        "tables"
+    ]
 )


### PR DESCRIPTION
Here I've changed the setup.py to automatically install the listed requirements (there was also an unlisted one called "pytables").
I have changed the `package_dir` and `package` to just `package` so it now starts at the correct root level (same as `setup.py`). 

You can test these changes by performing the following (in the appropriate venv):
```
cd .../scTOP
python setup.py sdist
```

Now there should be a tar file in the `dist` directory. Lets pretend this is the file downloaded from pip and install it manually:
```
pip install --force dist/scTOP-0.0.4.tar.gz
```

It will check for the dependencies for you then install on top of version 0.0.4.
Now lets check from python:
```
python
>> import sctop as top
>> top.load_basis('MC20-KO22', 0)
```
plus any other checks you feel are appropriate...